### PR TITLE
Add zc-lockfile to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.21.5
 tables>=3.7.0
 future>=0.18.2
 pytest>=6.2.4
+zc-lockfile>=3.0.post1


### PR DESCRIPTION
The dependency zc-lockfile seems to be missing.
After installing hdf5io ad trying to import Hdf5io, I get the error:
```
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
Cell In[3], line 1
----> 1 from hdf5io.hdf5io import Hdf5io

File /usr/local/lib/python3.11/dist-packages/hdf5io/hdf5io.py:11
      9 except:
     10     import Queue as queue
---> 11 import zc.lockfile
     12 import numpy
     13 import re

ModuleNotFoundError: No module named 'zc'
```

Installing zc-lockfile solves the issue.
I believe the lib should also be included in setup.py but, since you are not declaring the dependencies there, this PR is only for the requirements.txt.